### PR TITLE
Tweaking of several Components to match Figma Proto

### DIFF
--- a/components/About/Button.js
+++ b/components/About/Button.js
@@ -1,8 +1,9 @@
 import styles from '../../styles/Button.module.css'
+import {ImArrowUpRight2} from 'react-icons/im'
 const Button = (props) => {
     return (
         <div className={styles.btndiv}>
-            <button className={styles.btnh}>{props.name} 🡭</button>
+            <button className={styles.btnh}>{props.name}&emsp;{<ImArrowUpRight2/>}</button>
         </div>
     )
 }

--- a/components/Speakers/speakers.module.css
+++ b/components/Speakers/speakers.module.css
@@ -66,7 +66,7 @@
     padding-left:2rem; 
     margin-bottom: 3rem;
     
-    color:white;
+    color:#fdd7b6;
     
     /* -webkit-text-fill-color: white ;
     -webkit-text-stroke-width: .1rem;

--- a/components/Sponsor/Sponsor.module.css
+++ b/components/Sponsor/Sponsor.module.css
@@ -51,6 +51,7 @@
     font-family: var(--title);
     text-align: center;
     font-size: calc(1.5vw + 1vh + 2vmin);
+    padding: 0 0.2em;
     margin-top: 5vw;
     font-style: normal;
     font-weight: normal;

--- a/components/Sponsor/Sponsor.module.css
+++ b/components/Sponsor/Sponsor.module.css
@@ -3,9 +3,9 @@
     width: 100%;
     background: linear-gradient(
         180deg,
-        rgb(236, 216, 200) 0%,
-        rgb(230, 219, 210) 38%,
-        rgba(255, 255, 255, 1) 100%
+        #ffc089 0%,
+        #ffd9b7 10%,
+        #ffffff 40%
     );
 }
 .sponsorRow {
@@ -21,23 +21,21 @@
     text-align: center;
     font-style: normal;
     font-weight: normal;
-    font-size: 9vw;
-    text-shadow: -1.5px -1.5px 0 #000, 1.5px -1.5px 0 #000, -1.5px 1.5px 0 #000,
-        1.5px 1.5px 0 #000;
-    color: var(--white);
+    font-size: calc(5vw + 4vh + 3vmin);
+    text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
+        1px 1px 0 #000;
+    color: #ffd9b8;
     letter-spacing: 1.5px;
 }
 
 .prizeH2 {
     font-family: var(--title);
     text-align: center;
-    font-size: 6vw;
+    font-size: calc(2vw + 3vh + 3vmin);
     font-style: normal;
     margin-top: 5vw;
     font-weight: normal;
-    -webkit-text-fill-color: var(
-        --black
-    ); /* Will override color (regardless of order) */
+    -webkit-text-fill-color: var(--black); /* Will override color (regardless of order) */
     letter-spacing: -0.032em;
 }
 
@@ -52,17 +50,16 @@
 .prizeH3 {
     font-family: var(--title);
     text-align: center;
-    font-size: 3.5vw;
+    font-size: calc(1.5vw + 1vh + 2vmin);
     margin-top: 5vw;
     font-style: normal;
     font-weight: normal;
-    -webkit-text-fill-color: var(
-        --black
-    ); /* Will override color (regardless of order) */
+    -webkit-text-fill-color: var(--black); /* Will override color (regardless of order) */
 }
 .sponsorImg {
     margin-left: 3vw;
     margin-right: 3vw;
+    border-radius: 12px;
 }
 
 .sponsorLabel {

--- a/components/Sponsor/Sponsor.module.css
+++ b/components/Sponsor/Sponsor.module.css
@@ -24,7 +24,7 @@
     font-size: calc(5vw + 4vh + 3vmin);
     text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
         1px 1px 0 #000;
-    color: #ffd9b8;
+    color: #ffe1c7;
     letter-spacing: 1.5px;
 }
 

--- a/components/Sponsor/Sponsor.module.css
+++ b/components/Sponsor/Sponsor.module.css
@@ -21,7 +21,7 @@
     text-align: center;
     font-style: normal;
     font-weight: normal;
-    font-size: calc(5vw + 4vh + 3vmin);
+    font-size: calc(5vw + 4vh + 2vmin);
     text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
         1px 1px 0 #000;
     color: #ffe1c7;
@@ -31,7 +31,7 @@
 .prizeH2 {
     font-family: var(--title);
     text-align: center;
-    font-size: calc(2vw + 3vh + 3vmin);
+    font-size: calc(2vw + 3vh + 2vmin);
     font-style: normal;
     margin-top: 5vw;
     font-weight: normal;

--- a/components/Sponsor/Sponsor.module.css
+++ b/components/Sponsor/Sponsor.module.css
@@ -24,7 +24,7 @@
     font-size: calc(5vw + 4vh + 2vmin);
     text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
         1px 1px 0 #000;
-    color: #ffe1c7;
+    color: #ffdcbd;
     letter-spacing: 1.5px;
 }
 

--- a/components/Sponsor_Faq/FAQ.module.css
+++ b/components/Sponsor_Faq/FAQ.module.css
@@ -60,8 +60,8 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    margin-top: 35%;
-    margin-bottom: 25%;
+    margin-top: 23%;
+    margin-bottom: 22.5%;
 }
 .faq{
     padding-top: 10%;
@@ -77,7 +77,7 @@
     font-family: var(--title);
     text-shadow: -1px -1px 0 #000000, 1px -1px 0 #000000,
                  -1px 1px 0 #000000, 1px 1px 0 #000000;
-    color: #c28bff;   
+    color: #c48dfc;   
 }
 .subtitle{
     color: var(--black);
@@ -113,7 +113,7 @@
     padding: 4% 5.5% 4% 5.5%;
     margin-bottom: 1.2rem;
     border: 1px solid var(--black);
-    border-radius: 2rem;
+    border-radius: 5rem;
     border-bottom-right-radius: 0;
     box-shadow: 0.05rem 0.1rem 0.3rem var(--black);
 }
@@ -182,7 +182,7 @@
 /* large screens */
 @media screen and (min-width: 1024px) and (max-height: 1080px){
     .wrapper{
-        min-height: 135vh;
+        min-height: 101vh;
     }
     .FaqBack{
         top: 15rem;

--- a/components/Sponsor_Faq/FAQ.module.css
+++ b/components/Sponsor_Faq/FAQ.module.css
@@ -182,7 +182,7 @@
 /* large screens */
 @media screen and (min-width: 1024px) and (max-height: 1080px){
     .wrapper{
-        min-height: 101vh;
+        min-height: 67vw;
     }
     .FaqBack{
         top: 15rem;

--- a/styles/About.module.css
+++ b/styles/About.module.css
@@ -8,9 +8,9 @@
     background: rgb(255, 255, 255);
     background: linear-gradient(
         0deg,
-        rgba(255, 255, 255, 1) 1%,
-        rgba(255, 230, 230, 1) 50%,
-        rgba(255, 255, 255, 1) 100%
+        #ffffff 1%,
+        #ffe7d3 50%,
+        #ffffff 100%
     );
 }
 .title_container {
@@ -31,7 +31,7 @@
     color: var(--black);
 }
 .title > span {
-    color: var(--white);
+    color: #fff9f5;
     font-size: 7rem;
     text-shadow: -1px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000,
         1px 1px 0 #000;


### PR DESCRIPTION
# Description

Made small tweaks to several components to better match the Figma prototype and be more responsive.

- Corrected the Color of the Title in the About Us section
- Fixed the Arrow symbol of the About Us button not working on mobile
- Corrected the Color of the Title in the Speakers section
- Fixed the color of the Sponsors section the to Figma Design
- Made the text of the Sponsors section responsive to different screen sizes
- Added a border-radius to the sponsor logos
- Adjusted the distance between the black section and the word FAQ in the FAQ module on mobile devices
- Fixed the broken responsiveness of iPad Pro sizes
- Fixed the border radius of the chat bubbles

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Browsers Tested on?

- [x] Chrome
- [x] Firefox
- [x] Edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked the responsiveness of the component I built
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
