### PR TITLE
Adjusted margins in Sponsors to vertically space evenly on Mobile-sizes

### DIFF
--- a/components/Sponsor/Prizes.module.css
+++ b/components/Sponsor/Prizes.module.css
@@ -52,7 +52,7 @@
     font-family: var(--title);
     text-align: center;
     font-size: calc(0.7vw + 3vh + 2vmin); /*responsive font size w/o media queries*/
-    padding: 0 0.2em;
+    padding: 0 1em;
     margin-top: 4vw;
     font-style: normal;
     font-weight: normal;

--- a/components/Sponsor/Sponsor.module.css
+++ b/components/Sponsor/Sponsor.module.css
@@ -47,7 +47,7 @@
 
 .backPill{
     width:fit-content;
-    margin: 5vw auto 5em auto;
+    margin: 4em auto 5em auto;
     border-radius: 500px;
     background-color: #ffffff75;
     border: 3px solid #ffffffe9;
@@ -89,6 +89,9 @@
     .backPill {
         margin: 5vw auto 12em auto;
     }
+    .sponsorRow {
+        column-gap: 8em;
+    }
 }
 
 @media screen and (max-width: 415px) {
@@ -101,7 +104,10 @@
     }
     /* Stopping bottom Margin being too much on iP 6/6s and too less on iP X/Xs */
     .backPill {
-        margin: 5vw auto calc(2.6em + 5vh) auto;
+        margin: 2em auto 4.5em auto;
+    }
+    #Learn {
+        font-size: calc(1.2vw + 2.5vh + 3vmin);
     }
 }
 
@@ -116,6 +122,6 @@
         font-size: calc(0.85vw + 2.5vh + 3vmin);
     }
     .backPill {
-        margin: 5vw auto 3em auto;
+        margin: 1.5em auto 2em auto;
     }
 }

--- a/components/Sponsor/Sponsor.module.css
+++ b/components/Sponsor/Sponsor.module.css
@@ -104,7 +104,7 @@
     }
     /* Stopping bottom Margin being too much on iP 6/6s and too less on iP X/Xs */
     .backPill {
-        margin: 2em auto 4.5em auto;
+        margin: 2.25em auto 4.25em auto;
     }
     #Learn {
         font-size: calc(1.2vw + 2.5vh + 3vmin);

--- a/components/Sponsor/Sponsors.js
+++ b/components/Sponsor/Sponsors.js
@@ -40,7 +40,6 @@ export const Sponsors = (props) => {
                     Gold Tier
                 </h3></div>
                 <SponsorsRow sponsors={sponsors} />
-                <br />
                 <div className={styles.backPill}><h3 className={styles.sponsorH3} style={{ color: '#2ebdeb' }}>
                     Silver Tier
                 </h3></div>
@@ -53,7 +52,6 @@ export const Sponsors = (props) => {
                     Learning Partner
                 </h3></div>
                 <SponsorsRow sponsors={sponsors4} />
-                <br />
                 <div className={styles.backPill}><h3 className={styles.sponsorH3} id={styles.Ruby} style={{ color: '#ff6361' }}>
                     Ruby Tier
                 </h3></div>

--- a/data/sponsor.js
+++ b/data/sponsor.js
@@ -15,7 +15,7 @@ let sponsors2 = [
         id: 1,
         name: 'Yocket',
         link: 'https://yocket.com/',
-        logo: 'https://res.cloudinary.com/roshin/image/upload/v1634216565/yocket_swddms.png',
+        logo: 'https://res.cloudinary.com/roshin/image/upload/v1634897207/yocket_zkmr8p.png',
     },
 ]
 


### PR DESCRIPTION
# Description

Spaced the logos and tier labels a bit more evenly, should look more vertically centered now

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Browsers Tested on?

- [x] Chrome
- [x] Firefox
- [x] Edge

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have checked the responsiveness of the component I built
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
